### PR TITLE
2 minor changes + allow to paste source to a field on quickkey use

### DIFF
--- a/ir/importer.py
+++ b/ir/importer.py
@@ -41,9 +41,6 @@ from .util import setField
 
 class Importer:
     def _fetchWebpage(self, url):
-        if not urlsplit(url).scheme:
-            url = 'http://' + url
-
         if isMac:
             context = _create_unverified_context()
             html = urlopen(url, context=context).read().decode('utf-8')
@@ -92,6 +89,9 @@ class Importer:
         if not url or not accepted:
             return
 
+        if not urlsplit(url).scheme:
+            url = 'http://' + url
+
         try:
             webpage = self._fetchWebpage(url)
         except HTTPError as error:
@@ -102,8 +102,10 @@ class Importer:
             return
 
         body = '\n'.join(map(str, webpage.find('body').children))
-        source = self.settings['sourceFormat'].format(date=date.today(),
-                                                      url=url)
+        source = self.settings['sourceFormat'].format(
+            date=date.today(),
+            url='<a href="' + url + '">' + url + '</a>')
+
         self._createNote(webpage.title.string, body, source)
 
     def importFeed(self):

--- a/ir/importer.py
+++ b/ir/importer.py
@@ -104,7 +104,7 @@ class Importer:
         body = '\n'.join(map(str, webpage.find('body').children))
         source = self.settings['sourceFormat'].format(
             date=date.today(),
-            url='<a href="' + url + '">' + url + '</a>')
+            url='<a href="%s">%s</a></div>' % (url, url))
 
         self._createNote(webpage.title.string, body, source)
 

--- a/ir/importer.py
+++ b/ir/importer.py
@@ -104,7 +104,7 @@ class Importer:
         body = '\n'.join(map(str, webpage.find('body').children))
         source = self.settings['sourceFormat'].format(
             date=date.today(),
-            url='<a href="%s">%s</a></div>' % (url, url))
+            url='<a href="%s">%s</a>' % (url, url))
 
         self._createNote(webpage.title.string, body, source)
 

--- a/ir/importer.py
+++ b/ir/importer.py
@@ -21,7 +21,7 @@ from urllib.request import urlopen
 from anki.notes import Note
 from anki.utils import isMac, isWin
 from aqt import mw
-from aqt.utils import askUser, getText, openLink, showWarning
+from aqt.utils import askUser, getText, openLink, showWarning, tooltip
 
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import (QAbstractItemView,
@@ -81,6 +81,7 @@ class Importer:
         note.model()['did'] = did
         mw.col.addNote(note)
         mw.deckBrowser.show()
+        tooltip('Added to deck: ' + mw.col.decks.get(did)['name'])
 
     def importWebpage(self, url=None):
         if not url:

--- a/ir/settings.py
+++ b/ir/settings.py
@@ -149,6 +149,7 @@ class SettingsManager:
             'modelName',
             'regularKey',
             'shift',
+            'sourceField',
             'tags',
             'textField',
         ]
@@ -774,6 +775,7 @@ class SettingsManager:
         destDeckLabel = QLabel('Destination Deck')
         noteTypeLabel = QLabel('Note Type')
         textFieldLabel = QLabel('Paste Text to Field')
+        sourceFieldLabel = QLabel('Paste Source to Field')
         keyComboLabel = QLabel('Key Combination')
 
         self.quickKeysComboBox = QComboBox()
@@ -785,6 +787,7 @@ class SettingsManager:
         self.destDeckComboBox = QComboBox()
         self.noteTypeComboBox = QComboBox()
         self.textFieldComboBox = QComboBox()
+        self.sourceFieldComboBox = QComboBox()
         self.quickKeyEditExtractCheckBox = QCheckBox('Edit Extracted Note')
         self.quickKeyEditSourceCheckBox = QCheckBox('Edit Source Note')
         self.quickKeyPlainTextCheckBox = QCheckBox('Extract as Plain Text')
@@ -808,6 +811,10 @@ class SettingsManager:
         textFieldLayout = QHBoxLayout()
         textFieldLayout.addWidget(textFieldLabel)
         textFieldLayout.addWidget(self.textFieldComboBox)
+
+        sourceFieldLayout = QHBoxLayout()
+        sourceFieldLayout.addWidget(sourceFieldLabel)
+        sourceFieldLayout.addWidget(self.sourceFieldComboBox)
 
         keyComboLayout = QHBoxLayout()
         keyComboLayout.addWidget(keyComboLabel)
@@ -852,6 +859,7 @@ class SettingsManager:
         layout.addLayout(destDeckLayout)
         layout.addLayout(noteTypeLayout)
         layout.addLayout(textFieldLayout)
+        layout.addLayout(sourceFieldLayout)
         layout.addLayout(keyComboLayout)
         layout.addWidget(self.quickKeyEditExtractCheckBox)
         layout.addWidget(self.quickKeyEditSourceCheckBox)
@@ -871,6 +879,7 @@ class SettingsManager:
             setComboBoxItem(self.destDeckComboBox, settings['extractDeck'])
             setComboBoxItem(self.noteTypeComboBox, settings['modelName'])
             setComboBoxItem(self.textFieldComboBox, settings['textField'])
+            setComboBoxItem(self.sourceFieldComboBox, settings['sourceField'])
             self.ctrlKeyCheckBox.setChecked(settings['ctrl'])
             self.altKeyCheckBox.setChecked(settings['alt'])
             self.shiftKeyCheckBox.setChecked(settings['shift'])
@@ -886,10 +895,13 @@ class SettingsManager:
     def _updateFieldList(self):
         modelName = self.noteTypeComboBox.currentText()
         self.textFieldComboBox.clear()
+        self.sourceFieldComboBox.clear()
         if modelName:
             model = mw.col.models.byName(modelName)
             fieldNames = [f['name'] for f in model['flds']]
             self.textFieldComboBox.addItems(fieldNames)
+            self.sourceFieldComboBox.addItem('None')
+            self.sourceFieldComboBox.addItems(fieldNames)
 
     def _clearQuickKeysTab(self):
         self.quickKeysComboBox.setCurrentIndex(0)
@@ -931,6 +943,7 @@ class SettingsManager:
             'plainText': self.quickKeyPlainTextCheckBox.isChecked(),
             'regularKey': self.regularKeyComboBox.currentText(),
             'shift': self.shiftKeyCheckBox.isChecked(),
+            'sourceField': self.sourceFieldComboBox.currentText(),
             'tags': tags,
             'textField': self.textFieldComboBox.currentText(),
         }

--- a/ir/text.py
+++ b/ir/text.py
@@ -89,6 +89,11 @@ class TextManager:
 
         if settings['isQuickKey']:
             newNote.tags += settings['tags']
+            if settings['sourceField'] != "None":
+                setField(newNote, settings['sourceField'],
+                         '<div><br></div>(source: '+
+                         getField(currentNote, self.settings['sourceField'])
+                         + ')')
             if settings['editExtract']:
                 highlight = self._editExtract(newNote, did, settings)
             else:

--- a/ir/text.py
+++ b/ir/text.py
@@ -89,7 +89,7 @@ class TextManager:
 
         if settings['isQuickKey']:
             newNote.tags += settings['tags']
-            if settings['sourceField'] != "None":
+            if settings['sourceField'] != 'None':
                 setField(newNote, settings['sourceField'],
                          '<div><br></div>(source: '+
                          getField(currentNote, self.settings['sourceField'])

--- a/ir/util.py
+++ b/ir/util.py
@@ -103,9 +103,10 @@ def getField(note, fieldName):
 
 
 def setField(note, fieldName, content):
+    "Add content at the end of a field."
     model = note.model()
     index, _ = mw.col.models.fieldMap(model)[fieldName]
-    note.fields[index] = content
+    note.fields[index] += content
 
 
 def createSpinBox(value, minimum, maximum, step):


### PR DESCRIPTION
The blank line before '(source: ...)' is deliberate. If the Cloze type is used with the source in the 'Extra' field, it visually separates the text from the source; and whatever the note type, if the user wants to write something before the source in the same field, it's faster.