### PR TITLE
Fix issue when quickkey unset

### DIFF
--- a/ir/settings.py
+++ b/ir/settings.py
@@ -897,7 +897,6 @@ class SettingsManager:
     def _updateFieldLists(self):
         modelName = self.noteTypeComboBox.currentText()
         self.textFieldComboBox.clear()
-        self.sourceFieldComboBox.clear()
 
         if modelName:
             model = mw.col.models.byName(modelName)
@@ -907,12 +906,14 @@ class SettingsManager:
 
     def _updateSourceFieldComboBox(self):
             modelName = self.noteTypeComboBox.currentText()
-            model = mw.col.models.byName(modelName)
-            fieldNames = [f['name'] for f in model['flds']
-                          if f['name'] != self.textFieldComboBox.currentText()]
             self.sourceFieldComboBox.clear()
-            self.sourceFieldComboBox.addItem('')
-            self.sourceFieldComboBox.addItems(fieldNames)
+
+            if modelName:
+                model = mw.col.models.byName(modelName)
+                fieldNames = [f['name'] for f in model['flds']
+                        if f['name'] != self.textFieldComboBox.currentText()]
+                self.sourceFieldComboBox.addItem('')
+                self.sourceFieldComboBox.addItems(fieldNames)
 
     def _clearQuickKeysTab(self):
         self.quickKeysComboBox.setCurrentIndex(0)


### PR DESCRIPTION
Unsetting a quickkey would change the current index of self.textFieldComboBox, which would call _updateSourceFieldComboBox(), which would have modelName = "", model = None then raise the issue 'NoneType object is not subscriptable' because of model['flds']