### PR TITLE
Allow extraction and quickkeys with empty selection

### DIFF
--- a/ir/text.py
+++ b/ir/text.py
@@ -53,12 +53,12 @@ class TextManager:
         self.save()
 
     def extract(self, settings=None):
-        if not mw.web.selectedText():
-            showInfo('Please select some text to extract.')
-            return
-
         if not settings:
             settings = self.settings
+
+        if not mw.web.selectedText() and not settings['editExtract']:
+            showInfo('Please select some text to extract.')
+            return
 
         if settings['plainText']:
             mw.web.evalWithCallback(

--- a/ir/util.py
+++ b/ir/util.py
@@ -143,6 +143,8 @@ def updateModificationTime(path):
 
 
 def fixImages(html):
+    if not html:
+        return ''
     soup = BeautifulSoup(html, 'html.parser')
     for img in soup.find_all('img'):
         img['src'] = os.path.basename(unquote(img['src']))


### PR DESCRIPTION
Only if the extract is to be edited before being saved, otherwise it would create an empty note (or a note with only the source).
This way it doesn't seem possible to accidentally create a note with an empty first field, as Anki won't accept it in the AddCards window.