### PR TITLE
Save all highlight settings changes

### DIFF
--- a/ir/settings.py
+++ b/ir/settings.py
@@ -549,6 +549,8 @@ class SettingsManager:
                         self.settings['highlightBgColor'])
         self.bgColorComboBox.currentIndexChanged.connect(
             self._updateColorPreview)
+        self.bgColorComboBox.activated.connect(
+            self._saveHighlightSettings)  # activated: by the user
 
         self.textColorComboBox = QComboBox()
         self.textColorComboBox.addItems(colors)
@@ -556,6 +558,8 @@ class SettingsManager:
                         self.settings['highlightTextColor'])
         self.textColorComboBox.currentIndexChanged.connect(
             self._updateColorPreview)
+        self.textColorComboBox.activated.connect(
+            self._saveHighlightSettings)
 
         self.colorPreviewLabel = QLabel('Example Text')
         self._updateColorPreview()


### PR DESCRIPTION
Only the last highlight settings change would be saved.
Now all are saved, but as with quickkeys, this is (except for the last one) independent from the Close and Save buttons: if the user changes several highlight settings but decides to cancel that, it's not possible because they've already been saved.