### PR TITLE
Make sure to store original bridge and fall back on it when appropriate

### DIFF
--- a/ir/view.py
+++ b/ir/view.py
@@ -30,6 +30,7 @@ class ViewManager:
         self.textScript = loadFile('web', 'text.js')
         self.widthScript = loadFile('web', 'width.js')
         self.zoomFactor = 1
+        self.origBridgeCmd = None
         addHook('afterStateChange', self.resetZoom)
         addHook('prepareQA', self.prepareCard)
         mw.web.page().scrollPositionChanged.connect(self.saveScroll)
@@ -43,6 +44,7 @@ class ViewManager:
             js = ''
 
         if isIrCard(card) and context.startswith('review'):
+            self.origBridgeCmd = mw.web.onBridgeCmd
             mw.web.onBridgeCmd = self.storePageInfo
             cid = str(card.id)
 
@@ -72,6 +74,8 @@ class ViewManager:
             mw.web.evalWithCallback(
                 '[window.innerHeight, document.body.scrollHeight];', callback
             )
+        elif self.origBridgeCmd:
+            return self.origBridgeCmd(cmd)
 
     def setZoom(self, factor=None):
         if factor:


### PR DESCRIPTION
Hi luoliyan,

I noticed that some add-ons like Pop-up Dictionary or Edit Field During Reviews that depend on a custom link handler would stop working as soon as the first IR card appeared. It seems like this is because IR currently irreversibly overwrites mw.web.onBridgeCmd.

This commit introduces a quick and dirty change that let's IR keep track of the original onBridgeCmd and makes it fall back to it when appropriate. I've only done some preliminary testing, but it seems like all pertinent features like storing the page scroll position and zoom level still work well after this patch. And the add-ons mentioned above now work without any issues both when displaying IR cards and regular Anki cards.

(The implementation is not that beautiful, so please feel free to switch to a different approach at any point)

Thanks again for all your work on this project!

P.S.: This PR is part of an effort to curb common add-on conflicts in web views. Please see the other PRs referenced at the bottom [here](https://github.com/dae/anki/pull/228) for more information on this
