### PR TITLE
Allow for new argument in Anki 2.1.45

### DIFF
--- a/ir/main.py
+++ b/ir/main.py
@@ -216,10 +216,10 @@ def answerCard(self, ease, _old):
         mw.readingManager.scheduler.answer(card, ease)
 
 
-def buttonTime(self, i, _old):
+def buttonTime(self, *args, _old, **kwargs):
     if isIrCard(mw.reviewer.card):
         return '<div class=spacer></div>'
-    return _old(self, i)
+    return _old(self, *args, **kwargs)
 
 
 def onBrowserClosed(self):


### PR DESCRIPTION
In https://github.com/ankitects/anki/commit/49a1580566f403e445d186a4fbf4be1dcb4ff153
Anki gets a new argument for buttonTime. This PR supports both the old
and new argument types.